### PR TITLE
Add config setting to control if the active item is persistent on mou…

### DIFF
--- a/jquery.swiftype.autocomplete.js
+++ b/jquery.swiftype.autocomplete.js
@@ -192,6 +192,10 @@
         $element.click($this.selectedCallback(data)).mouseover(function () {
           $this.listResults().removeClass(config.activeItemClass);
           $element.addClass(config.activeItemClass);
+        }).mouseout(function () {
+          if (!config.persistentActiveItem) {
+            $this.listResults().removeClass(config.activeItemClass);
+          }
         });
       };
 
@@ -560,6 +564,7 @@
 
   $.fn.swiftype.defaults = {
     activeItemClass: 'active',
+    persistentActiveItem: true,
     attachTo: undefined,
     documentTypes: undefined,
     filters: undefined,


### PR DESCRIPTION
…seout

Allows control of if the enter key submits an autocomplete or a normal search following a mouse interaction